### PR TITLE
Defer wrapped CallExpressions

### DIFF
--- a/src/helpers/extract-expressions.js
+++ b/src/helpers/extract-expressions.js
@@ -1,15 +1,69 @@
 import isLiteralOrSpecial from "./is-literal-or-special";
+import * as t from "babel-types";
 
 function addClosureVar(expression, closureVars) {
   const init = expression.node;
   const id = expression.scope.generateUidIdentifierBasedOnNode(init);
 
   closureVars.push({ id, init });
-  expression.replaceWith(id);
+  return id;
 }
 
 function last(array) {
   return array[array.length - 1];
+}
+
+const collectDeferrables = {
+  CallExpression(path) {
+    if (deferrable(path)) {
+      const args = path.node.arguments;
+
+      this.deferred.push(path);
+      this.deferredArgs.push(args);
+      if (args.length) {
+        this.hasDeferredArgs = true;
+      }
+    }
+  },
+
+  LogicalExpression() {
+    this.branches += 2;
+  },
+
+  ConditionalExpression() {
+    this.branches += 2;
+  },
+
+  Function(path) {
+    path.skip();
+  }
+};
+
+
+function deferrable(ancestor) {
+  let last;
+  while ((last = ancestor, ancestor = ancestor.parentPath)) {
+    if (ancestor.isJSXElement()) {
+      return true;
+    }
+
+    if (ancestor.isSequenceExpression()) {
+      const expressions = ancestor.get("expressions");
+      if (expressions[expressions.length - 1] !== last) {
+        return false;
+      }
+    } else if (ancestor.isConditionalExpression()) {
+      if (last.key === "test") {
+        return false;
+      }
+    } else if (ancestor.isLogicalExpression()) {
+      if (ancestor.get("left") === last) {
+        return false;
+      }
+    } else if (!ancestor.isJSX()) {
+      return false;
+    }
+  }
 }
 
 // Extracts variable expressions into an array of closure parameters,
@@ -18,7 +72,9 @@ function last(array) {
 const expressionExtractor = {
   JSXSpreadAttribute(path) {
     const { closureVarsStack } = this;
-    addClosureVar(path.get("argument"), last(closureVarsStack));
+    const argument = path.get("argument");
+    const id = addClosureVar(argument, last(closureVarsStack));
+    argument.replaceWith(id)
   },
 
   JSXExpressionContainer(path) {
@@ -28,8 +84,159 @@ const expressionExtractor = {
       return;
     }
 
-    const { closureVarsStack } = this;
-    addClosureVar(expression, last(closureVarsStack));
+    const closureVars = last(this.closureVarsStack);
+
+    // Only call defer JSX Children Expressions
+    if (!path.parentPath.isJSXElement()) {
+      expression.replaceWith(addClosureVar(expression, closureVars));
+      return;
+    }
+
+    // Grab all our deferrable calls
+    const state = Object.assign({}, this, {
+      deferred: [],
+      deferredArgs: [],
+      branches: 0,
+    });
+    path.traverse(collectDeferrables, state);
+    const { deferred, deferredArgs, hasDeferredArgs, branches } = state;
+
+    // Exit early if there's nothing to defer.
+    if (deferred.length === 0) {
+      expression.replaceWith(addClosureVar(expression, closureVars));
+      return;
+    }
+
+    const everyBranchHasCall = deferred.length >= branches;
+    const onlyOneArg = deferredArgs.length === 1 && deferredArgs[0].length === 1;
+    let deferredId = path.scope.generateUidIdentifier("deferred");
+    let argId;
+    let branchId;
+
+    if (hasDeferredArgs) {
+      argId = path.scope.generateUidIdentifier("args");
+    }
+    if (branches > 0) {
+      branchId = path.scope.generateUidIdentifier("b");
+      path.scope.push({ id: branchId, init: t.numericLiteral(0) });
+    } else if (deferred.length > 1) {
+      throw expression.buildCodeFrameError("No branches?");
+    }
+
+    // Map our deferred calls into their important information
+    const calls = deferred.map((path, i) => {
+      const { node } = path;
+      const callee = path.get("callee");
+      const isMemberExpression = callee.isMemberExpression();
+
+      // Transform our calls into their context. For normal calls, it's just the
+      // function reference. For member expressions (`obj.fn()`), it's the `obj`.
+      // We'll invoke the function properly later on.
+      let context = isMemberExpression ? callee.node.object : callee.node;
+      if (branches > 0) {
+        context = t.sequenceExpression([
+          t.assignmentExpression("=", branchId, t.numericLiteral(i + 1)),
+          context
+        ]);
+      }
+      path.replaceWith(context);
+
+      return {
+        path,
+        node,
+        isMemberExpression,
+      }
+    });
+
+    // Now push the transformed expression into our closure variables.
+    // This cloned node has all the deferrable calls remapped into their contexts,
+    // and won't actually invoke them.
+    closureVars.push({ id: deferredId, init: t.cloneDeep(expression.node) });
+
+    // Now that we've evaluated the expression, we need to evaluate the arguments
+    // to the deferred call that "won", if any did.
+    if (argId) {
+      let init;
+      if (onlyOneArg) {
+        init = deferredArgs[0][0];
+      } else {
+        init = deferredArgs.map((args) => t.arrayExpression(args));
+        init = init.reduceRight((conditional, args, i) => {
+          if (!branchId || args.elements.length === 0) {
+            return conditional;
+          }
+
+          return t.conditionalExpression(
+            t.binaryExpression("==", branchId, t.numericLiteral(i + 1)),
+            args,
+            conditional
+          );
+        });
+      }
+      // If no branch "won", we need to evaluate to something else.
+      if (branchId) {
+        init = t.conditionalExpression(
+          t.binaryExpression("==", branchId, t.numericLiteral(0)),
+          t.nullLiteral(),
+          init
+        );
+      }
+      closureVars.push({ id: argId, init });
+    }
+
+    // Now, push the branching identifier.
+    if (branchId) {
+      closureVars.push({ id: branchId, init: branchId });
+    }
+
+    // Finally, transform the calls into their evaluted "contex" form.
+    const evaluatedBranches = calls.map((struct) => {
+      const { path, node, isMemberExpression } = struct;
+
+      // This reverses the context transform done earlier.
+      if (isMemberExpression) {
+        node.callee.object = deferredId;
+      } else {
+        node.callee = deferredId;
+      }
+
+      // Any arguments are now passed through the evaluated args array.
+      const args = node.arguments;
+      node.arguments = node.arguments.map((arg, i) => {
+        if (onlyOneArg) {
+          return argId;
+        }
+
+        return t.memberExpression(
+          argId,
+          t.numericLiteral(i),
+          true
+        );
+      });
+
+      return node;
+    });
+    let evaluated = evaluatedBranches.reduceRight((conditional, node, i) => {
+      if (!branchId) {
+        return node;
+      }
+
+      return t.conditionalExpression(
+        t.binaryExpression("==", branchId, t.numericLiteral(i + 1)),
+        node,
+        conditional
+      );
+    });
+    // If not every branch leads to a deferred call, we need to render the
+    // evaluated result. Ie. `1 || <div />` needs to render the `1`.
+    if (!everyBranchHasCall) {
+      evaluated = t.conditionalExpression(
+        t.binaryExpression("==", branchId, t.numericLiteral(0)),
+        deferredId,
+        evaluated
+      );
+    }
+    expression.replaceWith(evaluated);
   }
 };
 

--- a/src/helpers/extract-expressions.js
+++ b/src/helpers/extract-expressions.js
@@ -142,7 +142,6 @@ const expressionExtractor = {
       path.replaceWith(context);
 
       return {
-        path,
         node,
         isMemberExpression,
       }
@@ -191,7 +190,7 @@ const expressionExtractor = {
 
     // Finally, transform the calls into their evaluted "contex" form.
     const evaluatedBranches = calls.map((struct) => {
-      const { path, node, isMemberExpression } = struct;
+      const { node, isMemberExpression } = struct;
 
       // This reverses the context transform done earlier.
       if (isMemberExpression) {
@@ -201,7 +200,6 @@ const expressionExtractor = {
       }
 
       // Any arguments are now passed through the evaluated args array.
-      const args = node.arguments;
       node.arguments = node.arguments.map((arg, i) => {
         if (onlyOneArg) {
           return argId;

--- a/src/helpers/inline-expressions.js
+++ b/src/helpers/inline-expressions.js
@@ -26,7 +26,10 @@ const expressionInliner = {
     }
 
     const closureVars = [];
-    init.traverse(expressionExtractor, { closureVarsStack: [closureVars] });
+    const state = Object.assign({}, this, {
+      closureVarsStack: [closureVars]
+    });
+    init.traverse(expressionExtractor, state);
 
     expression.replaceWith(init.node);
     declarator.replaceWithMultiple(closureVars.map((cv) => {

--- a/src/helpers/is-literal-or-special.js
+++ b/src/helpers/is-literal-or-special.js
@@ -1,9 +1,15 @@
+import * as t from "babel-types";
+
 // Literals and `undefined` are treated as constant values in attributes and
 // children.
-export default function isLiteralOrUndefined(path) {
-  return path.isLiteral() ||
-    path.isUnaryExpression({ operator: "void" }) ||
-    path.isIdentifier({ name: "undefined" }) ||
-    path.isIdentifier({ name: "NaN" }) ||
-    path.isIdentifier({ name: "Infinity" });
+export default function isLiteralOrSpecial(path) {
+  return isLiteralOrSpecialNode(path.node);
+}
+
+export function isLiteralOrSpecialNode(node) {
+  return t.isLiteral(node) ||
+    t.isUnaryExpression(node, { operator: "void" }) ||
+    t.isIdentifier(node, { name: "undefined" }) ||
+    t.isIdentifier(node, { name: "NaN" }) ||
+    t.isIdentifier(node, { name: "Infinity" });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ export default function ({ types: t, traverse: _traverse }) {
       Program: {
         enter(path) {
           if (this.opts.inlineExpressions) {
-            path.traverse(expressionInliner);
+            path.traverse(expressionInliner, this);
           }
           setupInjector(this);
           setupHoists(this);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import isRootJSX from "./helpers/is-root-jsx";
 import isReturned from "./helpers/is-returned";
-import childAncestor from "./helpers/is-child-element";
+import ancestorExpression from "./helpers/ancestry";
 import { setupInjector, injectHelpers } from "./helpers/inject";
 import { setupHoists, hoist, addHoistedDeclarator } from "./helpers/hoist";
 
@@ -49,7 +49,7 @@ export default function ({ types: t, traverse: _traverse }) {
     JSXElement: {
       enter(path) {
         const { secondaryTree, root, closureVarsStack } = this;
-        const needsWrapper = secondaryTree || (root !== path && !childAncestor(path, this));
+        const needsWrapper = secondaryTree || (root !== path && !ancestorExpression(path, this));
 
         // If this element needs to be wrapped in a closure, we need to transform
         // it's children without wrapping them.
@@ -66,8 +66,8 @@ export default function ({ types: t, traverse: _traverse }) {
 
       exit(path) {
         const { root, secondaryTree, replacedElements, closureVarsStack } = this;
-        const childAncestorPath = childAncestor(path, this);
-        const needsWrapper = secondaryTree || (root !== path && !childAncestorPath);
+        const ancestorPath = ancestorExpression(path, this);
+        const needsWrapper = secondaryTree || (root !== path && !ancestorPath);
 
         const { parentPath } = path;
         const explicitReturn = parentPath.isReturnStatement();
@@ -124,8 +124,8 @@ export default function ({ types: t, traverse: _traverse }) {
           return;
         }
 
-        if (childAncestorPath) {
-          replacedElements.add(childAncestorPath);
+        if (ancestorPath) {
+          replacedElements.add(ancestorPath);
         }
 
         // This is the main JSX element. Replace the return statement

--- a/test/fixtures/call-expression-defer/wrapper/attributes/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/attributes/actual.js
@@ -1,0 +1,5 @@
+function render() {
+  function fn() {}
+  var div = <div attr={fn()} {...fn()}></div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/attributes/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/attributes/expected.js
@@ -6,6 +6,14 @@ var _jsxWrapper = function _jsxWrapper(func, args) {
   return wrapper;
 };
 
+var _flipAttr = function _flipAttr(value, name) {
+  attr(name, value);
+};
+
+var _spreadAttribute = function _spreadAttribute(spread) {
+  _forOwn(spread, _flipAttr);
+};
+
 var _hasOwn = Object.prototype.hasOwnProperty;
 
 var _forOwn = function _forOwn(object, iterator) {
@@ -28,31 +36,22 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+var _wrapper = function _wrapper(_fn, _fn2) {
+  elementOpenStart("div");
+  attr("attr", _fn);
 
-  _renderArbitrary(_deferred.map(_args));
+  _spreadAttribute(_fn2);
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
-
-  _renderArbitrary(_file$name2);
-
-  return elementClose("li");
+  elementOpenEnd("div");
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  function fn() {}
+  var div = _jsxWrapper(_wrapper, [fn(), fn()]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/call/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/call/actual.js
@@ -1,0 +1,5 @@
+function render() {
+  function fn() {}
+  var div = <div>{fn()}</div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/call/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/call/expected.js
@@ -28,31 +28,20 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+var _wrapper = function _wrapper(_deferred) {
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_deferred());
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
-
-  _renderArbitrary(_file$name2);
-
-  return elementClose("li");
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  function fn() {}
+  var div = _jsxWrapper(_wrapper, [fn]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/compound/eval.js
+++ b/test/fixtures/call-expression-defer/wrapper/compound/eval.js
@@ -1,0 +1,143 @@
+import { transform } from "babel-core";
+import assert from "assert";
+import plugin from "../../../../../src/index";
+
+const originals = [
+  '(1, 2, fn())',
+  '(true ? fn() : fn())',
+  '(true && fn())',
+  '(true || fn())',
+];
+
+let cases = [...originals];
+let tests = [...cases];
+for (let i = 0; i < cases.length; i++) {
+  const kase = cases[i];
+  for (let j = 0; j < cases.length; j++) {
+    const other = cases[j];
+    const compound = kase.replace(/fn\(\)/g, other);
+    tests.push(compound);
+  }
+}
+
+cases = tests;
+tests = [...cases];
+for (let i = 0; i < originals.length; i++) {
+  const kase = cases[i];
+  for (let j = originals.length; j < cases.length; j++) {
+    const other = cases[j];
+    const compound = kase.replace(/fn\(\)/g, other);
+    if ((i + 1) * 4 <= j && j < (i + 2) * 4) {
+      // console.log(compound);
+    } else if ((j - 4) % 5 === 0) {
+      // console.log(compound);
+    } else {
+      tests.push(compound);
+    }
+  }
+}
+
+cases = tests;
+tests = [];
+for (let i = 0; i < cases.length; i++) {
+  const kase = cases[i].split('fn()');
+
+  const perms = Math.pow(2, kase.length - 1);
+  for (let j = 0; j < perms; j++) {
+    const bits = j.toString(2).split('');
+    while (bits.length < kase.length - 1) {
+      bits.unshift("0");
+    }
+
+    let perm = kase[0];
+    for (let k = 1; k < kase.length; k++) {
+      perm += `${bits[k - 1] == "0" ? `"expression${k}"` : "fn()"}${kase[k]}`;
+    }
+    tests.push(perm)
+  }
+}
+
+cases = tests;
+tests = [];
+for (let i = 0; i < cases.length; i++) {
+  const kase = cases[i].split('true');
+
+  const perms = Math.pow(2, kase.length - 1);
+  for (let j = 0; j < perms; j++) {
+    const bits = j.toString(2).split('').map((b) => b == "1");
+
+    while (bits.length < kase.length - 1) {
+      bits.unshift(false);
+    }
+    let perm = kase[0];
+    for (let k = 1; k < kase.length; k++) {
+      perm += `${bits[k - 1]}${kase[k]}`;
+    }
+    tests.push(perm)
+  }
+}
+
+for (let i = 0; i < tests.length; i++) {
+  let fn = 0;
+  tests[i] = tests[i].replace(/fn\(\)/g, function() {
+    fn++;
+    return `fn${fn}(args[${fn - 1}]++)`;
+  });
+}
+
+
+let val;
+function elementOpen() { }
+function elementClose() { }
+function _renderArbitrary(v) {
+  val = v;
+}
+function elementVoid() { }
+function jsxWrapper(func, args) {
+  func.apply(null, args);
+}
+const args = Array(4);
+function fn1() {
+  return `fn1${args}`;
+}
+function fn2() {
+  return `fn2${args}`;
+}
+function fn3() {
+  return `fn3${args}`;
+}
+function fn4() {
+  return `fn4${args}`;
+}
+
+const runtimeModule = { renderArbitrary: _renderArbitrary, jsxWrapper };
+function mockRequire() {
+  return runtimeModule;
+}
+
+for (let i = 0; i < tests.length; i++) {
+  const test = tests[i]
+
+  it(test, () => {
+    val = '';
+    args.fill(0);
+
+    const expected = eval(test);
+    const expectedCount = args.reduce((sum, i) => sum + (i & 1));
+
+    const transformed = transform(`function render() { var div = <div>{${test}}</div>; return <div />; }; render()`, {
+      plugins: [
+        'transform-es2015-modules-commonjs',
+        [plugin, {runtimeModuleSource: 'test'}]
+      ]
+    }).code;
+
+    args.fill(0);
+    const require = mockRequire;
+    eval(transformed);
+    const count = args.reduce((sum, i) => sum + (i & 1));
+
+    assert.equal(val, expected);
+    assert.equal(count,expectedCount, 'arguments were eagerly evaluated');
+  });
+}

--- a/test/fixtures/call-expression-defer/wrapper/conditional/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/conditional/actual.js
@@ -1,0 +1,14 @@
+function render() {
+  function fn() {}
+  function fn2() {}
+  function fn3() {}
+  var div = <div>
+  {true ? fn2() : 'a'}
+  {true ? fn2() : fn3()}
+  {fn() ? fn2() : fn3()}
+  {1, 2, true ? fn2() : fn3()}
+  {true && (true ? fn2() : fn3())}
+  {true || (true ? fn2() : fn3())}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/conditional/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/conditional/expected.js
@@ -1,0 +1,68 @@
+'use strict';
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === 'number' || type === 'string' || type === 'object' && child instanceof String) {
+    text(child);
+  } else if (type === 'function' && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === 'object' && String(child) === '[object Object]') {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+var _wrapper = function _wrapper(_deferred, _b, _deferred2, _b2, _deferred3, _b3, _deferred4, _b4, _deferred5, _b5, _deferred6, _b6) {
+  elementOpen('div');
+
+  _renderArbitrary(_b == 0 ? _deferred : _deferred());
+
+  _renderArbitrary(_b2 == 1 ? _deferred2() : _deferred2());
+
+  _renderArbitrary(_b3 == 1 ? _deferred3() : _deferred3());
+
+  _renderArbitrary(_b4 == 1 ? _deferred4() : _deferred4());
+
+  _renderArbitrary(_b5 == 0 ? _deferred5 : _b5 == 1 ? _deferred5() : _deferred5());
+
+  _renderArbitrary(_b6 == 0 ? _deferred6 : _b6 == 1 ? _deferred6() : _deferred6());
+
+  return elementClose('div');
+};
+
+function render() {
+  var _b = 0,
+      _b2 = 0,
+      _b3 = 0,
+      _b4 = 0,
+      _b5 = 0,
+      _b6 = 0;
+
+  function fn() {}
+  function fn2() {}
+  function fn3() {}
+  var div = _jsxWrapper(_wrapper, [true ? (_b = 1, fn2) : 'a', _b, true ? (_b2 = 1, fn2) : (_b2 = 2, fn3), _b2, fn() ? (_b3 = 1, fn2) : (_b3 = 2, fn3), _b3, (1, 2, true ? (_b4 = 1, fn2) : (_b4 = 2, fn3)), _b4, true && (true ? (_b5 = 1, fn2) : (_b5 = 2, fn3)), _b5, true || (true ? (_b6 = 1, fn2) : (_b6 = 2, fn3)), _b6]);
+  elementOpen('root');
+
+  _renderArbitrary(div);
+
+  return elementClose('root');
+}

--- a/test/fixtures/call-expression-defer/wrapper/inner-call/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/inner-call/actual.js
@@ -1,0 +1,14 @@
+function renderMessage(i) {
+  return <em>{"my message " + i}</em>;
+}
+
+function render() {
+  var ul = <ul>
+  {
+    [0, 1, 2, 3, 4].map(
+      i => <li>{renderMessage(i)}</li>
+    )
+  }
+  </ul>;
+  return <root>{ul}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/inner-call/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/inner-call/expected.js
@@ -1,3 +1,11 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
 var _hasOwn = Object.prototype.hasOwnProperty;
 
 var _forOwn = function _forOwn(object, iterator) {
@@ -20,12 +28,19 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _jsxWrapper = function _jsxWrapper(func, args) {
-  var wrapper = args ? function wrapper() {
-    return func.apply(this, args);
-  } : func;
-  wrapper.__jsxDOMWrapper = true;
-  return wrapper;
+var _wrapper = function _wrapper(_deferred, _args) {
+  elementOpen("ul");
+
+  _renderArbitrary(_deferred.map(_args));
+
+  return elementClose("ul");
+},
+    _wrapper2 = function _wrapper2(_deferred2, _args2) {
+  elementOpen("li");
+
+  _renderArbitrary(_deferred2(_args2));
+
+  return elementClose("li");
 };
 
 function renderMessage(i) {
@@ -34,28 +49,13 @@ function renderMessage(i) {
   return elementClose("em");
 }
 
-function intermediate(i) {
-  return renderMessage(i);
-}
-
 function render() {
-  var a = _jsxWrapper(renderMessage, [1]);
-  var b = _jsxWrapper(intermediate, [1]);
-  var c = _jsxWrapper(renderMessage2, [1]);
-
+  var ul = _jsxWrapper(_wrapper, [[0, 1, 2, 3, 4], function (i) {
+    return _jsxWrapper(_wrapper2, [renderMessage, i]);
+  }]);
   elementOpen("root");
 
-  _renderArbitrary(a);
-
-  _renderArbitrary(b);
-
-  _renderArbitrary(c);
+  _renderArbitrary(ul);
 
   return elementClose("root");
-}
-
-function renderMessage2(i) {
-  elementOpen("em");
-  text("my message " + i);
-  return elementClose("em");
 }

--- a/test/fixtures/call-expression-defer/wrapper/logical/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/logical/actual.js
@@ -1,0 +1,14 @@
+function render() {
+  function fn() {}
+  var div = <div>
+  {true && fn()}
+  {true || fn()}
+  {fn() || true}
+  {fn() && true}
+  {1, 2, true && fn()}
+  {1, 2, true || fn()}
+  {true ? true && fn() : true && fn()}
+  {true ? true || fn() : true || fn()}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/logical/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/logical/expected.js
@@ -1,0 +1,68 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object" && String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+var _wrapper = function _wrapper(_deferred, _b, _deferred2, _b2, _ref, _ref2, _deferred3, _b3, _deferred4, _b4, _deferred5, _b5, _deferred6, _b6) {
+  elementOpen("div");
+
+  _renderArbitrary(_b == 0 ? _deferred : _deferred());
+
+  _renderArbitrary(_b2 == 0 ? _deferred2 : _deferred2());
+
+  _renderArbitrary(_ref);
+
+  _renderArbitrary(_ref2);
+
+  _renderArbitrary(_b3 == 0 ? _deferred3 : _deferred3());
+
+  _renderArbitrary(_b4 == 0 ? _deferred4 : _deferred4());
+
+  _renderArbitrary(_b5 == 0 ? _deferred5 : _b5 == 1 ? _deferred5() : _deferred5());
+
+  _renderArbitrary(_b6 == 0 ? _deferred6 : _b6 == 1 ? _deferred6() : _deferred6());
+
+  return elementClose("div");
+};
+
+function render() {
+  var _b = 0,
+      _b2 = 0,
+      _b3 = 0,
+      _b4 = 0,
+      _b5 = 0,
+      _b6 = 0;
+
+  function fn() {}
+  var div = _jsxWrapper(_wrapper, [true && (_b = 1, fn), _b, true || (_b2 = 1, fn), _b2, fn() || true, fn() && true, (1, 2, true && (_b3 = 1, fn)), _b3, (1, 2, true || (_b4 = 1, fn)), _b4, true ? true && (_b5 = 1, fn) : true && (_b5 = 2, fn), _b5, true ? true || (_b6 = 1, fn) : true || (_b6 = 2, fn), _b6]);
+  elementOpen("root");
+
+  _renderArbitrary(div);
+
+  return elementClose("root");
+}

--- a/test/fixtures/call-expression-defer/wrapper/member-call/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/member-call/actual.js
@@ -1,0 +1,5 @@
+function render() {
+  var a = { b: { fn() { } } };
+  var div = <div>{a.b.fn()}</div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/member-call/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/member-call/expected.js
@@ -28,31 +28,22 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+var _wrapper = function _wrapper(_deferred) {
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_deferred.fn());
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
-
-  _renderArbitrary(_file$name2);
-
-  return elementClose("li");
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  var a = { b: {
+      fn: function fn() {}
+    } };
+  var div = _jsxWrapper(_wrapper, [a.b]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/call/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/call/actual.js
@@ -1,0 +1,6 @@
+function render() {
+  var div = <div>
+  {fn(i++)}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/call/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/call/expected.js
@@ -29,30 +29,18 @@ var _renderArbitrary = function _renderArbitrary(child) {
 };
 
 var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_deferred(_args));
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
-
-  _renderArbitrary(_file$name2);
-
-  return elementClose("li");
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  var div = _jsxWrapper(_wrapper, [fn, i++]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/conditional/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/conditional/actual.js
@@ -1,0 +1,7 @@
+function render() {
+  var div = <div>
+  {true ? fn(a++) : fn2(b++, c++)}
+  {fn(i++) ? fn(a++) : fn2(b++, c++)}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/conditional/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/conditional/expected.js
@@ -42,7 +42,7 @@ function render() {
   var _b = 0,
       _b2 = 0;
 
-  var div = _jsxWrapper(_wrapper, [true ? (_b = 1, fn) : (_b = 2, fn2), _b == 0 ? null : _b == 1 ? [a++] : [b++, c++], _b, fn(i++) ? (_b2 = 1, fn) : (_b2 = 2, fn2), _b2 == 0 ? null : _b2 == 1 ? [a++] : [b++, c++], _b2]);
+  var div = _jsxWrapper(_wrapper, [true ? (_b = 1, fn) : (_b = 2, fn2), _b == 1 ? [a++] : [b++, c++], _b, fn(i++) ? (_b2 = 1, fn) : (_b2 = 2, fn2), _b2 == 1 ? [a++] : [b++, c++], _b2]);
   elementOpen("root");
 
   _renderArbitrary(div);

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/conditional/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/conditional/expected.js
@@ -28,31 +28,24 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+var _wrapper = function _wrapper(_deferred, _args, _b, _deferred2, _args2, _b2) {
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_b == 1 ? _deferred(_args[0]) : _deferred(_args[0], _args[1]));
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
+  _renderArbitrary(_b2 == 1 ? _deferred2(_args2[0]) : _deferred2(_args2[0], _args2[1]));
 
-  _renderArbitrary(_file$name2);
-
-  return elementClose("li");
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  var _b = 0,
+      _b2 = 0;
+
+  var div = _jsxWrapper(_wrapper, [true ? (_b = 1, fn) : (_b = 2, fn2), _b == 0 ? null : _b == 1 ? [a++] : [b++, c++], _b, fn(i++) ? (_b2 = 1, fn) : (_b2 = 2, fn2), _b2 == 0 ? null : _b2 == 1 ? [a++] : [b++, c++], _b2]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/logical/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/logical/actual.js
@@ -1,0 +1,7 @@
+function render() {
+  var div = <div>
+  {true && fn(i++)}
+  {true || fn(i++)}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/logical/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/logical/expected.js
@@ -28,31 +28,24 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+var _wrapper = function _wrapper(_deferred, _args, _b, _deferred2, _args2, _b2) {
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_b == 0 ? _deferred : _deferred(_args));
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
+  _renderArbitrary(_b2 == 0 ? _deferred2 : _deferred2(_args2));
 
-  _renderArbitrary(_file$name2);
-
-  return elementClose("li");
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  var _b = 0,
+      _b2 = 0;
+
+  var div = _jsxWrapper(_wrapper, [true && (_b = 1, fn), _b == 0 ? null : i++, _b, true || (_b2 = 1, fn), _b2 == 0 ? null : i++, _b2]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/member-call/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/member-call/actual.js
@@ -1,0 +1,6 @@
+function render() {
+  var div = <div>
+  {a.b.fn(i++)}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/member-call/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/member-call/expected.js
@@ -29,30 +29,18 @@ var _renderArbitrary = function _renderArbitrary(child) {
 };
 
 var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_deferred.fn(_args));
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
-
-  _renderArbitrary(_file$name2);
-
-  return elementClose("li");
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  var div = _jsxWrapper(_wrapper, [a.b, i++]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/sequence/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/sequence/actual.js
@@ -1,0 +1,6 @@
+function render() {
+  var div = <div>
+  {1, 2, fn(i++)}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/mutated-params/sequence/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/mutated-params/sequence/expected.js
@@ -29,30 +29,18 @@ var _renderArbitrary = function _renderArbitrary(child) {
 };
 
 var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_deferred(_args));
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
-
-  _renderArbitrary(_file$name2);
-
-  return elementClose("li");
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  var div = _jsxWrapper(_wrapper, [(1, 2, fn), i++]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/optimizations/literal-args/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/optimizations/literal-args/actual.js
@@ -1,0 +1,8 @@
+function render() {
+  function fn() {}
+  var div = <div>
+  {fn(1, true, i, 'test')}
+  {fn(1, a, 2, i, 'test')}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/optimizations/literal-args/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/optimizations/literal-args/expected.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === 'number' || type === 'string' || type === 'object' && child instanceof String) {
+    text(child);
+  } else if (type === 'function' && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === 'object' && String(child) === '[object Object]') {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+var _wrapper = function _wrapper(_deferred, _args, _deferred2, _args2) {
+  elementOpen('div');
+
+  _renderArbitrary(_deferred(1, true, _args, 'test'));
+
+  _renderArbitrary(_deferred2(1, _args2[1], 2, _args2[3], 'test'));
+
+  return elementClose('div');
+};
+
+function render() {
+  function fn() {}
+  var div = _jsxWrapper(_wrapper, [fn, i, fn, [a, i]]);
+  elementOpen('root');
+
+  _renderArbitrary(div);
+
+  return elementClose('root');
+}

--- a/test/fixtures/call-expression-defer/wrapper/optimizations/single-arg/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/optimizations/single-arg/actual.js
@@ -1,0 +1,9 @@
+function render() {
+  function fn() {}
+  var div = <div>
+  {fn(args)}
+  {true ? fn(args) : fn2()}
+  {true ? fn() : fn2(args)}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/optimizations/single-arg/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/optimizations/single-arg/expected.js
@@ -28,12 +28,14 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _wrapper = function _wrapper(_deferred, _args, _b, _deferred2, _args2, _b2) {
+var _wrapper = function _wrapper(_deferred, _args, _deferred2, _args2, _b, _deferred3, _args3, _b2) {
   elementOpen("div");
 
-  _renderArbitrary(_b == 1 ? _deferred(_args[0]) : _deferred(_args[0], _args[1]));
+  _renderArbitrary(_deferred(_args));
 
-  _renderArbitrary(_b2 == 1 ? _deferred2(_args2[0]) : _deferred2(_args2[0], _args2[1]));
+  _renderArbitrary(_b == 1 ? _deferred2(_args2) : _deferred2());
+
+  _renderArbitrary(_b2 == 1 ? _deferred3() : _deferred3(_args3));
 
   return elementClose("div");
 };
@@ -42,7 +44,8 @@ function render() {
   var _b = 0,
       _b2 = 0;
 
-  var div = _jsxWrapper(_wrapper, [true ? (_b = 1, fn) : (_b = 2, fn2), _b == 1 ? [a++] : [b++, c++], _b, fn(i++) ? (_b2 = 1, fn) : (_b2 = 2, fn2), _b2 == 1 ? [a++] : [b++, c++], _b2]);
+  function fn() {}
+  var div = _jsxWrapper(_wrapper, [fn, args, true ? (_b = 1, fn) : (_b = 2, fn2), args, _b, true ? (_b2 = 1, fn) : (_b2 = 2, fn2), args, _b2]);
   elementOpen("root");
 
   _renderArbitrary(div);

--- a/test/fixtures/call-expression-defer/wrapper/sequence/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/sequence/actual.js
@@ -1,0 +1,12 @@
+function render() {
+  function fn() {}
+  function fn2() {}
+  var div = <div>
+  {1, 2, fn2()}
+  {1, fn(), fn2()}
+  {true ? (1, 2, fn2()) : (1, 2, fn2())}
+  {true && (1, fn(), fn2())}
+  {true || (1, fn(), fn2())}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/sequence/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/sequence/expected.js
@@ -28,31 +28,33 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+var _wrapper = function _wrapper(_deferred, _deferred2, _deferred3, _b, _deferred4, _b2, _deferred5, _b3) {
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_deferred());
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
+  _renderArbitrary(_deferred2());
 
-  _renderArbitrary(_file$name2);
+  _renderArbitrary(_b == 1 ? _deferred3() : _deferred3());
 
-  return elementClose("li");
+  _renderArbitrary(_b2 == 0 ? _deferred4 : _deferred4());
+
+  _renderArbitrary(_b3 == 0 ? _deferred5 : _deferred5());
+
+  return elementClose("div");
 };
 
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  var _b = 0,
+      _b2 = 0,
+      _b3 = 0;
+
+  function fn() {}
+  function fn2() {}
+  var div = _jsxWrapper(_wrapper, [(1, 2, fn2), (1, fn(), fn2), true ? (1, 2, (_b = 1, fn2)) : (1, 2, (_b = 2, fn2)), _b, true && (1, fn(), (_b2 = 1, fn2)), _b2, true || (1, fn(), (_b3 = 1, fn2)), _b3]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/spread/actual.js
+++ b/test/fixtures/call-expression-defer/wrapper/spread/actual.js
@@ -1,0 +1,9 @@
+function render() {
+  function fn() {}
+  var div = <div>
+  {fn(...args)}
+  {fn(1, ...args)}
+  {fn.test(...args)}
+  </div>;
+  return <root>{div}</root>;
+}

--- a/test/fixtures/call-expression-defer/wrapper/spread/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/spread/expected.js
@@ -28,31 +28,26 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _wrapper = function _wrapper(_deferred, _args) {
-  elementOpen("ul");
+var _wrapper = function _wrapper(_deferred, _args, _deferred2, _args2, _deferred3, _args3) {
+  elementOpen("div");
 
-  _renderArbitrary(_deferred.map(_args));
+  _renderArbitrary(_deferred.apply(_args[0], _args[1]));
 
-  return elementClose("ul");
-},
-    _statics = ["key", ""],
-    _wrapper2 = function _wrapper2(_file$name, _file, _ref, _file$name2) {
-  elementOpen("li", _file$name, (_statics[1] = _file$name, _statics), "file", _file, "onclick", _ref);
+  _renderArbitrary(_deferred2.apply(_args2[0], _args2[1]));
 
-  _renderArbitrary(_file$name2);
+  _renderArbitrary(_deferred3.apply(_args3[0], _args3[1]));
 
-  return elementClose("li");
+  return elementClose("div");
 };
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 function render() {
-  var ul = _jsxWrapper(_wrapper, [files, function (file) {
-    return _jsxWrapper(_wrapper2, [file.name, file, function (e) {
-      return fileClicked(e, file);
-    }, file.name]);
-  }]);
+  function fn() {}
+  var div = _jsxWrapper(_wrapper, [fn, [undefined, _toConsumableArray(args)], fn, [undefined, [1].concat(_toConsumableArray(args))], fn.test, [fn, _toConsumableArray(args)]]);
   elementOpen("root");
 
-  _renderArbitrary(ul);
+  _renderArbitrary(div);
 
   return elementClose("root");
 }

--- a/test/fixtures/call-expression-defer/wrapper/spread/expected.js
+++ b/test/fixtures/call-expression-defer/wrapper/spread/expected.js
@@ -31,9 +31,9 @@ var _renderArbitrary = function _renderArbitrary(child) {
 var _wrapper = function _wrapper(_deferred, _args, _deferred2, _args2, _deferred3, _args3) {
   elementOpen("div");
 
-  _renderArbitrary(_deferred.apply(_args[0], _args[1]));
+  _renderArbitrary(_deferred.apply(undefined, _args));
 
-  _renderArbitrary(_deferred2.apply(_args2[0], _args2[1]));
+  _renderArbitrary(_deferred2.apply(undefined, _args2));
 
   _renderArbitrary(_deferred3.apply(_args3[0], _args3[1]));
 
@@ -44,7 +44,7 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 function render() {
   function fn() {}
-  var div = _jsxWrapper(_wrapper, [fn, [undefined, _toConsumableArray(args)], fn, [undefined, [1].concat(_toConsumableArray(args))], fn.test, [fn, _toConsumableArray(args)]]);
+  var div = _jsxWrapper(_wrapper, [fn, _toConsumableArray(args), fn, [1].concat(_toConsumableArray(args)), fn.test, [fn, _toConsumableArray(args)]]);
   elementOpen("root");
 
   _renderArbitrary(div);

--- a/test/fixtures/inline-expressions/function-nested-elements/expected.js
+++ b/test/fixtures/inline-expressions/function-nested-elements/expected.js
@@ -33,13 +33,14 @@ var _wrapper = function _wrapper() {
 };
 
 function render() {
-  var _lis$map = lis.map(function (li) {
+  var _deferred = lis,
+      _args = function _args(li) {
     return _jsxWrapper(_wrapper);
-  });
+  };
   elementOpen("root");
   elementOpen("ul");
 
-  _renderArbitrary(_lis$map);
+  _renderArbitrary(_deferred.map(_args));
 
   elementClose("ul");
   return elementClose("root");

--- a/test/fixtures/wrapped-calls/variables/expected.js
+++ b/test/fixtures/wrapped-calls/variables/expected.js
@@ -1,0 +1,61 @@
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object" && String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+function renderMessage(i) {
+  elementOpen("em");
+  text("my message " + i);
+  return elementClose("em");
+}
+
+function intermediate(i) {
+  return renderMessage(i);
+}
+
+function render() {
+  var a = _jsxWrapper(renderMessage, [1]);
+  var b = _jsxWrapper(intermediate, [1]);
+  var c = _jsxWrapper(renderMessage2, [1]);
+
+  elementOpen("root");
+
+  _renderArbitrary(a);
+
+  _renderArbitrary(b);
+
+  _renderArbitrary(c);
+
+  return elementClose("root");
+}
+
+function renderMessage2(i) {
+  elementOpen("em");
+  text("my message " + i);
+  return elementClose("em");
+}


### PR DESCRIPTION
This finds `CallExpression`s inside `JSXElement`s that will be wrapped, and defers the call until the wrapper is executed.

Only calls that are the result of the expression will be deferred, not calls that control the code flow.

- Deferred
  - `{true && em("text")}`
  - `{true || em("text")}`
  - `{1, 2, em("text")}`
  - `{true ? em("text") : em("other")}`
- Not Deferred
  - `{fn() && "text"}`
  - `{fn() || "text"}`
  - `{1, fn(), "text"}`
  - `{fn() ? "text" : "other"}`

This pretty elegantly fixes #65, since it's uncommon to have JSX returning functions in the control flow. Down sides are the call's side effects aren't run, which may actually be an upside 🙃.

Note that the deferred calls arguments _will_ be evaluated before the wrapper is executed (like it wasn't deferred).

/cc @mairatma