### PR TITLE
Detect patch calls as JSX Roots

### DIFF
--- a/src/helpers/ancestry.js
+++ b/src/helpers/ancestry.js
@@ -1,21 +1,6 @@
+import useFastRoot from "./use-fast-root";
+
 const map = new WeakMap();
-
-function useFastRoot(path, { fastRoot = false }) {
-  path.find((path) => {
-    const comments = path.node.leadingComments;
-
-    return comments && comments.find((comment) => {
-      const match = /@incremental-dom.+(enable|disable)-fastRoot/.exec(comment.value);
-
-      if (match) {
-        fastRoot = match[1] === "enable";
-        return true;
-      }
-    });
-  });
-
-  return fastRoot;
-}
 
 function ancestry(ancestor, fastRoot) {
   let path = ancestor;

--- a/src/helpers/build-children.js
+++ b/src/helpers/build-children.js
@@ -23,7 +23,6 @@ function isStringConcatenation(path) {
 
 // Transforms the children into an array of iDOM function calls
 export default function buildChildren(children, plugin) {
-  let renderArbitraryRef;
   const { replacedElements } = plugin;
 
   children = children.reduce((children, child) => {
@@ -64,13 +63,11 @@ export default function buildChildren(children, plugin) {
 
       node = toFunctionCall(iDOMMethod("text", plugin), [value]);
     } else if (isStringConcatenation(child)) {
-      node = toFunctionCall(iDOMMethod("text", plugin), [child.node]);
+      node = toFunctionCall(iDOMMethod("text", plugin), [node]);
     } else if (wasInExpressionContainer && !replacedElements.has(child)) {
       // Arbitrary expressions, e.g. variables, need to be inspected at runtime
       // to determine how to render them.
-      renderArbitraryRef = renderArbitraryRef || injectRenderArbitrary(plugin);
-
-      node = toFunctionCall(renderArbitraryRef, [node]);
+      node = toFunctionCall(injectRenderArbitrary(plugin), [node]);
     }
 
     children.push(node);

--- a/src/helpers/idom-method.js
+++ b/src/helpers/idom-method.js
@@ -1,27 +1,12 @@
 import toReference from "./ast/to-reference";
-import resolvePath from "./resolve-path";
+import moduleSource from "./module-source";
 
 // Returns a reference to an iDOM method.
 export default function iDOMMethod(method, plugin) {
-  const { opts, file } = plugin;
-  let { moduleSource } = opts;
+  const importSource = moduleSource(plugin);
 
-  if (moduleSource) {
-    moduleSource = resolvePath(file.opts.filename, moduleSource);
-  } else {
-    // See if we can find the incremental-dom import.
-    const { imports } = file.metadata.modules;
-    const imported = imports.find((imported) => {
-      return imported.source === "incremental-dom";
-    });
-
-    if (imported) {
-      moduleSource = "incremental-dom";
-    }
-  }
-
-  if (moduleSource) {
-    return file.addImport(moduleSource, method);
+  if (importSource) {
+    return plugin.file.addImport(importSource, method);
   }
 
   return toReference(method);

--- a/src/helpers/is-root-jsx.js
+++ b/src/helpers/is-root-jsx.js
@@ -47,7 +47,7 @@ function inPatchRoot(path, plugin) {
     return imported.source === importSource;
   });
 
-  if (iDOMImport && iDOMImport.imported.includes('patch')) {
+  if (iDOMImport && iDOMImport.imported.includes("patch")) {
     const patchImport = iDOMImport.specifiers.find((imported) => {
       return imported.imported === "patch";
     });
@@ -59,7 +59,7 @@ function inPatchRoot(path, plugin) {
         patchRoots.push(parentPath);
       }
     });
-  } else if (iDOMImport && iDOMImport.imported.includes('*')) {
+  } else if (iDOMImport && iDOMImport.imported.includes("*")) {
     const starImport = iDOMImport.specifiers.find((imported) => {
       return imported.kind === "namespace";
     });

--- a/src/helpers/is-root-jsx.js
+++ b/src/helpers/is-root-jsx.js
@@ -47,7 +47,7 @@ function inPatchRoot(path, plugin) {
     return imported.source === importSource;
   });
 
-  if (iDOMImport && iDOMImport.imported.includes("patch")) {
+  if (iDOMImport && iDOMImport.imported.indexOf("patch") > -1) {
     const patchImport = iDOMImport.specifiers.find((imported) => {
       return imported.imported === "patch";
     });
@@ -59,7 +59,7 @@ function inPatchRoot(path, plugin) {
         patchRoots.push(parentPath);
       }
     });
-  } else if (iDOMImport && iDOMImport.imported.includes("*")) {
+  } else if (iDOMImport && iDOMImport.imported.indexOf("*") > -1) {
     const starImport = iDOMImport.specifiers.find((imported) => {
       return imported.kind === "namespace";
     });
@@ -81,7 +81,7 @@ function inPatchRoot(path, plugin) {
 
 
   return !patchRoots.length || path.findParent((parent) => {
-    return patchRoots.includes(parent);
+    return patchRoots.indexOf(parent) > -1;
   });
 }
 

--- a/src/helpers/module-source.js
+++ b/src/helpers/module-source.js
@@ -1,0 +1,20 @@
+import resolvePath from "./resolve-path";
+
+// Determines the import module source for iDOM.
+export default function moduleSource({ opts, file }) {
+  let { moduleSource } = opts;;
+  if (moduleSource) {
+    return resolvePath(file.opts.filename, moduleSource);
+  }
+
+  // See if we can find the incremental-dom import.
+  const { imports } = file.metadata.modules;
+  const imported = imports.find((imported) => {
+    return imported.source === "incremental-dom";
+  });
+
+  if (imported) {
+    return "incremental-dom";
+  }
+}
+

--- a/src/helpers/module-source.js
+++ b/src/helpers/module-source.js
@@ -2,7 +2,7 @@ import resolvePath from "./resolve-path";
 
 // Determines the import module source for iDOM.
 export default function moduleSource({ opts, file }) {
-  let { moduleSource } = opts;;
+  let { moduleSource } = opts;
   if (moduleSource) {
     return resolvePath(file.opts.filename, moduleSource);
   }

--- a/src/helpers/use-fast-root.js
+++ b/src/helpers/use-fast-root.js
@@ -1,0 +1,20 @@
+// Determines if this JSX element has fast-root enabled or disabled.
+// Fast root may be explicitly set using inline comments, and defaults
+// to the global option value.
+export default function useFastRoot(path, { fastRoot = false }) {
+  path.find((path) => {
+    const comments = path.node.leadingComments;
+
+    return comments && comments.find((comment) => {
+      const match = /@incremental-dom.+(enable|disable)-fastRoot/.exec(comment.value);
+
+      if (match) {
+        fastRoot = match[1] === "enable";
+        return true;
+      }
+    });
+  });
+
+  return fastRoot;
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ export default function ({ types: t, traverse: _traverse }) {
       const previousRoot = this.root;
       const sameLevel = !previousRoot || previousRoot.getFunctionParent() === path.getFunctionParent();
 
-      if (sameLevel && isRootJSX(path)) {
+      if (sameLevel && isRootJSX(path, this)) {
         this.root = path;
         const state = Object.assign({}, this, {
           secondaryTree: !isReturned(path),

--- a/test/fixtures/patch-root/69/actual.js
+++ b/test/fixtures/patch-root/69/actual.js
@@ -1,0 +1,13 @@
+import { patch } from "incremental-dom";
+
+const obj = {
+  get template() {
+    return <span>Hello</span>;
+  },
+
+  render() {
+    patch(this.container, () => {
+      return <div>{this.template}</div>;
+    });
+  }
+}

--- a/test/fixtures/patch-root/69/expected.js
+++ b/test/fixtures/patch-root/69/expected.js
@@ -1,0 +1,64 @@
+var _incrementalDom = require("incremental-dom");
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _incrementalDom.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+var _span$wrapper = function _span$wrapper() {
+  (0, _incrementalDom.elementOpen)("span");
+  (0, _incrementalDom.text)("Hello");
+  return (0, _incrementalDom.elementClose)("span");
+};
+
+var obj = {
+  get template() {
+    return _jsxWrapper(_span$wrapper);
+  },
+
+  render: function render() {
+    var _this = this;
+
+    (0, _incrementalDom.patch)(this.container, function () {
+      (0, _incrementalDom.elementOpen)("div");
+
+      _renderArbitrary(_this.template);
+
+      return (0, _incrementalDom.elementClose)("div");
+    });
+  }
+};

--- a/test/fixtures/patch-root/class/actual.js
+++ b/test/fixtures/patch-root/class/actual.js
@@ -1,0 +1,13 @@
+import { patch } from "incremental-dom";
+
+class Component {
+  template(data) {
+    return <div>
+    {items.map(x => <li>x.text</li>)}
+    </div>;
+  }
+
+  render() {
+    patch(this.element, this.template, this.data);
+  }
+}

--- a/test/fixtures/patch-root/class/expected.js
+++ b/test/fixtures/patch-root/class/expected.js
@@ -1,0 +1,76 @@
+var _incrementalDom = require("incremental-dom");
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _incrementalDom.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _li$wrapper = function _li$wrapper() {
+  (0, _incrementalDom.elementOpen)("li");
+  (0, _incrementalDom.text)("x.text");
+  return (0, _incrementalDom.elementClose)("li");
+};
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Component = function () {
+  function Component() {
+    _classCallCheck(this, Component);
+  }
+
+  _createClass(Component, [{
+    key: "template",
+    value: function template(data) {
+      (0, _incrementalDom.elementOpen)("div");
+
+      _renderArbitrary(items.map(function (x) {
+        return _jsxWrapper(_li$wrapper);
+      }));
+
+      return (0, _incrementalDom.elementClose)("div");
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      (0, _incrementalDom.patch)(this.element, this.template, this.data);
+    }
+  }]);
+
+  return Component;
+}();

--- a/test/fixtures/patch-root/extracted-render/actual.js
+++ b/test/fixtures/patch-root/extracted-render/actual.js
@@ -1,0 +1,9 @@
+import { patch } from "incremental-dom";
+
+function render(items) {
+  return <div>
+  {items.map(x => <li>x.text</li>)}
+  </div>;
+}
+
+patch(container, render, items);

--- a/test/fixtures/patch-root/extracted-render/expected.js
+++ b/test/fixtures/patch-root/extracted-render/expected.js
@@ -1,0 +1,58 @@
+var _incrementalDom = require("incremental-dom");
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _incrementalDom.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _li$wrapper = function _li$wrapper() {
+  (0, _incrementalDom.elementOpen)("li");
+  (0, _incrementalDom.text)("x.text");
+  return (0, _incrementalDom.elementClose)("li");
+};
+
+function render(items) {
+  (0, _incrementalDom.elementOpen)("div");
+
+  _renderArbitrary(items.map(function (x) {
+    return _jsxWrapper(_li$wrapper);
+  }));
+
+  return (0, _incrementalDom.elementClose)("div");
+}
+
+(0, _incrementalDom.patch)(container, render, items);

--- a/test/fixtures/patch-root/fast-root/actual.js
+++ b/test/fixtures/patch-root/fast-root/actual.js
@@ -1,0 +1,10 @@
+import { patch } from "incremental-dom";
+
+const todoItems = function(items) {
+  // @incremental-dom enable-fastRoot
+  return items.map(x => <li>x.text</li>);
+}
+
+patch(container, () => {
+  return <div>{todoItems(items)}</div>;
+});

--- a/test/fixtures/patch-root/fast-root/expected.js
+++ b/test/fixtures/patch-root/fast-root/expected.js
@@ -1,0 +1,49 @@
+var _incrementalDom = require("incremental-dom");
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _incrementalDom.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+var todoItems = function todoItems(items) {
+  // @incremental-dom enable-fastRoot
+  return items.map(function (x) {
+    (0, _incrementalDom.elementOpen)("li");
+    (0, _incrementalDom.text)("x.text");
+    return (0, _incrementalDom.elementClose)("li");
+  });
+};
+
+(0, _incrementalDom.patch)(container, function () {
+  (0, _incrementalDom.elementOpen)("div");
+
+  _renderArbitrary(todoItems(items));
+
+  return (0, _incrementalDom.elementClose)("div");
+});

--- a/test/fixtures/patch-root/import-specifier/actual.js
+++ b/test/fixtures/patch-root/import-specifier/actual.js
@@ -1,0 +1,7 @@
+import { patch } from "incremental-dom";
+
+const todoItems = items.map(x => <li>x.text</li>);
+
+patch(container, () => {
+  return <div>{todoItems}</div>;
+});

--- a/test/fixtures/patch-root/import-specifier/expected.js
+++ b/test/fixtures/patch-root/import-specifier/expected.js
@@ -1,0 +1,58 @@
+var _incrementalDom = require("incremental-dom");
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _incrementalDom.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+var _li$wrapper = function _li$wrapper() {
+  (0, _incrementalDom.elementOpen)("li");
+  (0, _incrementalDom.text)("x.text");
+  return (0, _incrementalDom.elementClose)("li");
+};
+
+var todoItems = items.map(function (x) {
+  return _jsxWrapper(_li$wrapper);
+});
+
+(0, _incrementalDom.patch)(container, function () {
+  (0, _incrementalDom.elementOpen)("div");
+
+  _renderArbitrary(todoItems);
+
+  return (0, _incrementalDom.elementClose)("div");
+});

--- a/test/fixtures/patch-root/import-wildcard/actual.js
+++ b/test/fixtures/patch-root/import-wildcard/actual.js
@@ -1,0 +1,7 @@
+import * as iDOM from "incremental-dom";
+
+const todoItems = items.map(x => <li>x.text</li>);
+
+iDOM.patch(container, () => {
+  return <div>{todoItems}</div>;
+});

--- a/test/fixtures/patch-root/import-wildcard/expected.js
+++ b/test/fixtures/patch-root/import-wildcard/expected.js
@@ -1,0 +1,62 @@
+var _incrementalDom = require("incremental-dom");
+
+var iDOM = _interopRequireWildcard(_incrementalDom);
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _incrementalDom.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+var _li$wrapper = function _li$wrapper() {
+  (0, _incrementalDom.elementOpen)("li");
+  (0, _incrementalDom.text)("x.text");
+  return (0, _incrementalDom.elementClose)("li");
+};
+
+var todoItems = items.map(function (x) {
+  return _jsxWrapper(_li$wrapper);
+});
+
+iDOM.patch(container, function () {
+  (0, _incrementalDom.elementOpen)("div");
+
+  _renderArbitrary(todoItems);
+
+  return (0, _incrementalDom.elementClose)("div");
+});

--- a/test/fixtures/patch-root/module-source-import-specifier/actual.js
+++ b/test/fixtures/patch-root/module-source-import-specifier/actual.js
@@ -1,0 +1,7 @@
+import { patch } from "idom-wrapper";
+
+const todoItems = items.map(x => <li>x.text</li>);
+
+patch(container, () => {
+  return <div>{todoItems}</div>;
+});

--- a/test/fixtures/patch-root/module-source-import-specifier/expected.js
+++ b/test/fixtures/patch-root/module-source-import-specifier/expected.js
@@ -1,0 +1,58 @@
+var _idomWrapper = require("idom-wrapper");
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _idomWrapper.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+var _li$wrapper = function _li$wrapper() {
+  (0, _idomWrapper.elementOpen)("li");
+  (0, _idomWrapper.text)("x.text");
+  return (0, _idomWrapper.elementClose)("li");
+};
+
+var todoItems = items.map(function (x) {
+  return _jsxWrapper(_li$wrapper);
+});
+
+(0, _idomWrapper.patch)(container, function () {
+  (0, _idomWrapper.elementOpen)("div");
+
+  _renderArbitrary(todoItems);
+
+  return (0, _idomWrapper.elementClose)("div");
+});

--- a/test/fixtures/patch-root/module-source-import-specifier/options.json
+++ b/test/fixtures/patch-root/module-source-import-specifier/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "moduleSource": "idom-wrapper"
+  }
+}

--- a/test/fixtures/patch-root/module-source-import-wildcard/actual.js
+++ b/test/fixtures/patch-root/module-source-import-wildcard/actual.js
@@ -1,0 +1,7 @@
+import * as iDOM from "idom-wrapper";
+
+const todoItems = items.map(x => <li>x.text</li>);
+
+iDOM.patch(container, () => {
+  return <div>{todoItems}</div>;
+});

--- a/test/fixtures/patch-root/module-source-import-wildcard/expected.js
+++ b/test/fixtures/patch-root/module-source-import-wildcard/expected.js
@@ -1,0 +1,62 @@
+var _idomWrapper = require("idom-wrapper");
+
+var iDOM = _interopRequireWildcard(_idomWrapper);
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _idomWrapper.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+var _li$wrapper = function _li$wrapper() {
+  (0, _idomWrapper.elementOpen)("li");
+  (0, _idomWrapper.text)("x.text");
+  return (0, _idomWrapper.elementClose)("li");
+};
+
+var todoItems = items.map(function (x) {
+  return _jsxWrapper(_li$wrapper);
+});
+
+iDOM.patch(container, function () {
+  (0, _idomWrapper.elementOpen)("div");
+
+  _renderArbitrary(todoItems);
+
+  return (0, _idomWrapper.elementClose)("div");
+});

--- a/test/fixtures/patch-root/module-source-import-wildcard/options.json
+++ b/test/fixtures/patch-root/module-source-import-wildcard/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "moduleSource": "idom-wrapper"
+  }
+}

--- a/test/fixtures/patch-root/no-import/actual.js
+++ b/test/fixtures/patch-root/no-import/actual.js
@@ -1,0 +1,5 @@
+const todoItems = items.map(x => <li>x.text</li>);
+
+iDOM.patch(container, () => {
+  return <div>{todoItems}</div>;
+});

--- a/test/fixtures/patch-root/no-import/expected.js
+++ b/test/fixtures/patch-root/no-import/expected.js
@@ -1,0 +1,44 @@
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    text(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+var todoItems = items.map(function (x) {
+  elementOpen("li");
+  text("x.text");
+  return elementClose("li");
+});
+
+iDOM.patch(container, function () {
+  elementOpen("div");
+
+  _renderArbitrary(todoItems);
+
+  return elementClose("div");
+});

--- a/test/fixtures/patch-root/object/actual.js
+++ b/test/fixtures/patch-root/object/actual.js
@@ -1,0 +1,14 @@
+import { patch } from "incremental-dom";
+
+function Component() {
+}
+
+Component.prototype.template = function(data) {
+  return <div>
+  {items.map(x => <li>x.text</li>)}
+  </div>;
+}
+
+Component.prototype.render = function() {
+  patch(this.element, this.template, this.data);
+}

--- a/test/fixtures/patch-root/object/expected.js
+++ b/test/fixtures/patch-root/object/expected.js
@@ -1,0 +1,62 @@
+var _incrementalDom = require("incremental-dom");
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || type === "object" && child instanceof String) {
+    (0, _incrementalDom.text)(child);
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (type === "object") {
+    if (child.__jsxDOMWrapper) {
+      var func = child.func,
+          args = child.args;
+
+      if (args) {
+        func.apply(this, args);
+      } else {
+        func();
+      }
+    } else if (String(child) === "[object Object]") {
+      _forOwn(child, _renderArbitrary);
+    }
+  }
+};
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _li$wrapper = function _li$wrapper() {
+  (0, _incrementalDom.elementOpen)("li");
+  (0, _incrementalDom.text)("x.text");
+  return (0, _incrementalDom.elementClose)("li");
+};
+
+function Component() {}
+
+Component.prototype.template = function (data) {
+  (0, _incrementalDom.elementOpen)("div");
+
+  _renderArbitrary(items.map(function (x) {
+    return _jsxWrapper(_li$wrapper);
+  }));
+
+  return (0, _incrementalDom.elementClose)("div");
+};
+
+Component.prototype.render = function () {
+  (0, _incrementalDom.patch)(this.element, this.template, this.data);
+};

--- a/test/fixtures/patch-root/requires-root-node/actual.js
+++ b/test/fixtures/patch-root/requires-root-node/actual.js
@@ -1,0 +1,7 @@
+import { patch } from "incremental-dom";
+
+function todoItems() {
+  return items.map(x => <li>x.text</li>);
+}
+
+patch(container, () => {todoItems()});

--- a/test/fixtures/patch-root/requires-root-node/expected.js
+++ b/test/fixtures/patch-root/requires-root-node/expected.js
@@ -1,0 +1,25 @@
+var _incrementalDom = require("incremental-dom");
+
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  return {
+    __jsxDOMWrapper: true,
+    func: func,
+    args: args
+  };
+};
+
+var _li$wrapper = function _li$wrapper() {
+  (0, _incrementalDom.elementOpen)("li");
+  (0, _incrementalDom.text)("x.text");
+  return (0, _incrementalDom.elementClose)("li");
+};
+
+function todoItems() {
+  return items.map(function (x) {
+    return _jsxWrapper(_li$wrapper);
+  });
+}
+
+(0, _incrementalDom.patch)(container, function () {
+  todoItems();
+});


### PR DESCRIPTION
If you `import { patch } from “incremental-dom”`, then we will only allow the patch’s `CallExpressions` to contain root JSX elements.

```js
import { patch } from “incremental-dom”;

// These will not be considered “root” nodes any longer
// That means that `todos` is an array of jsxWrappers containing the <li>.
const todos = lis.map(text => <li>{text}</li>);

// Only patch calls can contain root nodes
patch(container, () => {
  // This passes root node detection, because it is returned and is inside patch call.
  return <ul>{todos}</ul>;
});
```