### PR TITLE
Add uuidPrefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ static attributes will be deoptimized into the dynamic attributes list.
 ```js
 // Disabled (default)
 var _statics = ["key", "key", "href", "http://key/specified"];
-var _statics2 = ["key", "8ad02822-f391-48fb-a277-8065f7f92a99", "href", "http://example.com"];
-var _statics3 = ["key", "adbe4414-e6ad-41c0-aae2-1ca578653119", "href", "http://other.com"];
+var _statics2 = ["href", "http://example.com"];
+var _statics3 = ["href", "http://other.com"];
 
 function render() {
   elementVoid("a", "key", _statics);
@@ -200,6 +200,46 @@ plugin:
   "plugins": [[
     "transform-incremental-dom", {
       "requireStaticsKey": true
+    }
+  ]]
+}
+```
+
+#### UUID Prefix
+
+Together with automatic UUID generation, you can specify a UUID "prefix"
+that will allow for shorter automatic keys. You must ensure that this
+prefix will not conflict with any other value you use as a key.
+
+When using the UUID prefix, a simple counter is used instead of creating
+a true UUID.
+
+```js
+// Disabled (default)
+var _statics = ["href", "http://example.com"];
+
+function render() {
+  elementVoid("a", "8ad02822-f391-48fb-a277-8065f7f92a99", _statics);
+}
+```
+
+```js
+// Enabled ("uuid-")
+var _statics = ["href", "http://example.com"];
+
+function render() {
+  elementVoid("a", "uuid-1", _statics);
+}
+```
+
+To do this, simply add the `uuidPrefix` option to the Incremental DOM
+plugin:
+
+```json
+{
+  "plugins": [[
+    "transform-incremental-dom", {
+      "uuidPrefix": "uuid-"
     }
   ]]
 }

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -110,7 +110,7 @@ export default function extractOpenArguments(path, plugin) {
   const hasStatic = !!attrs.find(({ isStatic }) => isStatic);
   if (hasStatic && !key && !requireStaticsKey) {
     // Generate a UUID to be used as the key.
-    key = t.stringLiteral(uuid());
+    key = t.stringLiteral(uuid(plugin));
   }
   if (hasStatic && key) {
     const staticAttrs = [];

--- a/src/helpers/uuid.js
+++ b/src/helpers/uuid.js
@@ -1,8 +1,15 @@
 import { randomBytes } from "crypto";
 
+let i = 1;
+
 // @jed's brilliantly short UUID v4 generator
 // https://gist.github.com/jed/982883
-export default function uuid() {
+export default function uuid({ opts }) {
+  const { uuidPrefix } = opts;
+  if (uuidPrefix) {
+    return uuidPrefix + i++;
+  }
+
   return "00000000-0000-4000-8000-000000000000".replace(/[08]/g, randomizer);
 }
 

--- a/test/fixtures/uuid-prefix/actual.js
+++ b/test/fixtures/uuid-prefix/actual.js
@@ -1,0 +1,5 @@
+function render() {
+  return <div id="test">
+    <a href="/test"><span key="123" class="test">test</span></a>
+  </div>;
+}

--- a/test/fixtures/uuid-prefix/expected.js
+++ b/test/fixtures/uuid-prefix/expected.js
@@ -1,0 +1,12 @@
+var _span$statics = ["key", "123", "class", "test"],
+    _a$statics = ["href", "/test"],
+    _div$statics = ["id", "test"];
+function render() {
+  elementOpen("div", "uuid-2", _div$statics);
+  elementOpen("a", "uuid-1", _a$statics);
+  elementOpen("span", "123", _span$statics);
+  text("test");
+  elementClose("span");
+  elementClose("a");
+  return elementClose("div");
+}

--- a/test/fixtures/uuid-prefix/options.json
+++ b/test/fixtures/uuid-prefix/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "uuidPrefix": "uuid-"
+  }
+}


### PR DESCRIPTION
This allow you to specify a unique "prefix" to be used (with a counter) instead of generating a UUID.

Fixes #85.